### PR TITLE
Add new drill point properties to points api v1

### DIFF
--- a/api/1/point/points/get/response-example.json
+++ b/api/1/point/points/get/response-example.json
@@ -142,7 +142,11 @@
     "type": "AsbuiltHolePoint",
     "x": 123,
     "y": 123,
-    "z": 123
+    "z": 123,
+    "drillBitDia": 64,
+    "operatorName": "JFK",
+    "minimumDrillingLength": 6,
+    "subDrillingDepth": 0.3
   },
   {
     "abandoned": false,
@@ -169,6 +173,9 @@
     "type": "AsbuiltHolePoint",
     "x": 123,
     "y": 123,
-    "z": 456
+    "z": 117.5,
+    "operatorName": "JFK",
+    "minimumDrillingLength": 6,
+    "subDrillingDepth": 0.3
   }
 ]

--- a/api/1/point/points/get/response.json
+++ b/api/1/point/points/get/response.json
@@ -109,20 +109,22 @@
             "type": "string",
             "description": "Object type information",
             "enum": [
-              "SurveyPoint",
-              "SurveyLinePoint",
-              "AsbuiltPoint",
               "AsbuiltLinePoint",
+              "AsbuiltPoint",
               "AsbuiltSurfacePoint",
+              "AsbuiltHolePoint",
               "ControlPoint",
-              "UserPoint",
-              "UserLinePoint",
-              "UserMeshPoint",
-              "OffsetPoint",
+              "DrillPoint",
               "OffsetLinePoint",
               "OffsetMeshPoint",
-              "UserStringLineLayer",
-              "OffsetStringLineLayer"
+              "OffsetPoint",
+              "OffsetStringLineLayer",
+              "SurveyLinePoint",
+              "SurveyPoint",
+              "UserLinePoint",
+              "UserMeshPoint",
+              "UserPoint",
+              "UserStringLineLayer"
             ],
             "example": "SurveyPoint"
           },
@@ -210,6 +212,22 @@
           },
           "length": {
             "description": "Depth of the drilled hole",
+            "type": "number"
+          },
+          "drillBitDiameter": {
+            "description": "Diameter of the drill bit in millimeters",
+            "type": "number"
+          },
+          "operatorName": {
+            "description": "Name or personal identifier of the machine operator who logged the point",
+            "type": "string"
+          },
+          "minimumDrillingLength": {
+            "description": "The minimum drilling length required for an acceptable drill hole",
+            "type": "number"
+          },
+          "subDrillingDepth": {
+            "description": "The length by which the drilling is required to exceed the final filled in rock level",
             "type": "number"
           }
         }


### PR DESCRIPTION
Add the new optional properties drillBitDiameter, operatorName, minimumDrillingLength, subDrillingDepth properties for the point type AsbuiltHolePoint.
Add the AsbuiltHolePoint to the type enum, sorting the types ascending.